### PR TITLE
Types support.

### DIFF
--- a/elements/viewer-domain/viewer-domain.html
+++ b/elements/viewer-domain/viewer-domain.html
@@ -3,6 +3,8 @@
 <link rel="import"
       href="../viewer-method/viewer-method.html">
 <link rel="import"
+      href="../viewer-type/viewer-type.html">
+<link rel="import"
       href="../html-echo/html-echo.html">
 
 <dom-module id="viewer-domain">
@@ -32,7 +34,7 @@
       </section>
 
       <section class="events" hidden="{{!domain.events}}">
-        <h3>{{domain.name}} Events</h3>
+        <h3><span>{{domain.name}}</span> Events</h3>
 
         <div>
           <template is="dom-repeat" items="{{domain.events}}" as="event">
@@ -41,6 +43,23 @@
               description="{{event.description}}"
               parameters="{{event.parameters}}"
               ></viewer-method>
+          </template>
+        </div>
+      </section>
+
+      <section class="types" hidden="{{!domain.types}}">
+        <h3><span>{{domain.name}}</span> Types</h3>
+
+        <div>
+          <template is="dom-repeat" items="{{domain.types}}" as="type">
+            <viewer-type
+              name="{{type.id}}"
+              description="{{type.description}}"
+              type="{{type.type}}"
+              object-properties="{{type.properties}}"
+              allowed-values="{{type.enum}}"
+              array-items="{{type.items}}"
+              ></viewer-type>
           </template>
         </div>
       </section>

--- a/elements/viewer-method/viewer-method.html
+++ b/elements/viewer-method/viewer-method.html
@@ -19,20 +19,20 @@
             name="{{param.name}}"
             description="{{param.description}}"
             optional="{{param.optional}}"
-            type="{{param.type}}"></viewer-param>
+            type="{{param.type}}"
+            ref="{{param.$ref}}"></viewer-param>
         </template>
       </dl>
 
-
       <h5 hidden="{{isEmpty(returns)}}">Return object</h5>
-      <dl class="parameter-list returns" hidden="{{isEmpty(returns)}}">
+      <dl class="parameter-list" hidden="{{isEmpty(returns)}}">
         <template is="dom-repeat" items="{{returns}}" as="ret">
           <viewer-param
             name="{{ret.name}}"
             description="{{ret.description}}"
             optional="{{ret.optional}}"
             type="{{ret.type}}"
-            ref="{{ret.ref}}"></viewer-param>
+            ref="{{ret.$ref}}"></viewer-param>
         </template>
       </dl>
     </div>
@@ -47,9 +47,7 @@
         returns: Object
       },
       isEmpty: function(paramObj){
-        if (!paramObj) return true;
-        if (paramObj.length == 0) return true;
-        return false;
+        return !paramObj || !paramObj.length;
       },
       ready: function() {
         this.parameters = null;

--- a/elements/viewer-param/viewer-param.html
+++ b/elements/viewer-param/viewer-param.html
@@ -3,15 +3,14 @@
 <link rel="import"
       href="../html-echo/html-echo.html">
 
-<!-- we're not showing `type` info, yet. -->
-
 <dom-module id="viewer-param">
   <template>
     <div class="param-pair">
       <dt class="param-name monospace" class$="{{getCSSClass(optional)}}">{{name}}</dt>
       <dd class="param-def">
-        <html-echo html="{{description}}"></html-echo>
-        <span hidden="{{description}}">No description</span>
+        <span class="param-type" hidden="{{isEmpty(type)}}">{{type}}</span>
+        <span class="param-type" hidden="{{isEmpty(ref)}}">{{ref}}</span>
+        <html-echo class="param-desc" html="{{description}}"></html-echo>
       </dd>
     </div>
   </template>
@@ -34,9 +33,16 @@
   dd {
     flex: 3 0 0;
     margin-left: 20px;
+
+    display: flex;
+    flex-direction: column;
   }
   dt, dd {
     vertical-align: text-top;
+  }
+
+  .param-type {
+    font-weight: bold;
   }
 
   .optional {
@@ -60,6 +66,13 @@
         optional: Boolean,
         type: String,
         ref: String
+      },
+      ready: function() {
+        this.type = null;
+        this.ref = null;
+      },
+      isEmpty: function(value) {
+        return !value || !value.trim().length;
       },
       getCSSClass: function(optional) {
 

--- a/elements/viewer-type/viewer-type.html
+++ b/elements/viewer-type/viewer-type.html
@@ -1,0 +1,69 @@
+<link rel="import"
+      href="../../bower_components/polymer/polymer.html">
+<link rel="import"
+      href="../viewer-param/viewer-param.html">
+<link rel="import"
+      href="../html-echo/html-echo.html">
+
+<dom-module id="viewer-type">
+  <template>
+    <div>
+      <h4 class="type-name monospace">{{name}}</h4>
+
+      <p class="type-description"><html-echo html="{{description}}"></html-echo></p>
+      <p class="type-type">Type: <strong>{{type}}</strong></p>
+
+      <h5 hidden="{{isEmpty(objectProperties)}}">Properties</h5>
+      <dl class="parameter-list" hidden="{{isEmpty(objectProperties)}}">
+        <template is="dom-repeat" items="{{objectProperties}}" as="property">
+          <viewer-param
+            name="{{property.name}}"
+            description="{{property.description}}"
+            optional="{{property.optional}}"
+            type="{{property.type}}"
+            ref="{{property.$ref}}"></viewer-param>
+        </template>
+      </dl>
+
+      <h5 hidden="{{isEmpty(allowedValues)}}">Allowed values</h5>
+      <p hidden="{{isEmpty(allowedValues)}}">{{joinValues(allowedValues)}}</p>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: 'viewer-type',
+      properties: {
+        name: String,
+        description: String,
+        type: String,
+        objectProperties: Object,
+        allowedValues: Object,
+        arrayItems: Object
+      },
+      ready: function() {
+        this.objectProperties = null;
+        this.allowedValues = null;
+        this.arrayItems = null;
+      },
+      isEmpty: function(paramObj){
+        return !paramObj || !paramObj.length;
+      },
+      joinValues: function(array) {
+        return array && Array.isArray(array) && array.join(', ');
+      }
+    });
+  </script>
+  <style>
+    .parameter-list{
+      border: 2px solid hsl(0, 0%, 85%);
+      border-radius: 5px;
+      margin: 0 10%;
+    }
+    @media (max-width: 980px) {
+      .parameter-list{
+        margin: 0;
+      }
+    }
+
+  </style>
+</dom-module>


### PR DESCRIPTION
Showing type for each property in events/methods:
![types for event/method properties](https://i.imgur.com/dKvHsqu.png)

'Types' section at the bottom of each domain page:
!['types' section](https://i.imgur.com/exqn1rZ.png)

Fixes #12 