### PR TITLE
Prevent property description from breaking into multiple lines when it…

### DIFF
--- a/_includes/param.html
+++ b/_includes/param.html
@@ -20,11 +20,12 @@
       {% assign referral=param["$ref"] %}
       <span class="param-type">{% include type-referral.html referral=referral %}</span>
     {% endif %}
+    <span class="param-description">
+      {{ param.description }}
 
-    {{ param.description }}
-
-    {% if param.enum[0] %}
-      Allowed values: {{ param.enum | join: ', ' }}.
-    {% endif %}
+      {% if param.enum[0] %}
+        Allowed values: {{ param.enum | join: ', ' }}.
+      {% endif %}
+    </span>
   </dd>
 </div>


### PR DESCRIPTION
… contains `<code>` blocks. Fixes #28.

<img width="265" alt="screen shot 2015-07-16 at 01 15 01" src="https://cloud.githubusercontent.com/assets/985504/8712197/93d97944-2b59-11e5-8198-b9c05931cfc2.png">
