### PR TITLE
Update README for consistent protocol naming

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # debugging-protocol-viewer
 Explore the Chrome Debugging Protocol, its methods, events and basic documentation.
 
-More on the [Chrome DevTools debugger protocol](https://developer.chrome.com/devtools/docs/debugger-protocol)
+More on the [Chrome DevTools Debugging Protocol](https://developer.chrome.com/devtools/docs/debugger-protocol)
 
 
 ##  Building


### PR DESCRIPTION
Got confused for a moment when I read the README due to `debugging` and `debugger`.