### PR TITLE
Fix domain files generator

### DIFF
--- a/_domains/FileSystem.html
+++ b/_domains/FileSystem.html
@@ -1,4 +1,0 @@
----
-title: FileSystem
-idx: 14
----

--- a/_domains/ScreenOrientation.html
+++ b/_domains/ScreenOrientation.html
@@ -1,4 +1,0 @@
----
-title: ScreenOrientation
-idx: 27
----

--- a/_domains/Timeline.html
+++ b/_domains/Timeline.html
@@ -1,4 +1,0 @@
----
-title: Timeline
-idx: 18
----

--- a/create-domain-files.js
+++ b/create-domain-files.js
@@ -5,28 +5,27 @@
  */
 
 const fs = require('fs');
+const DOMAINS_FOLDER = '_domains/';
+const PROTOCOL_FILE = '_data/protocol.json';
 
 clearDomainsFolder();
 generateDomainFiles();
 
 function clearDomainsFolder() {
-  const path = '_domains/';
-  fs.readdirSync(path).forEach((file, index) => {
-    fs.unlinkSync(path + '/' + file);
-  });
+  fs.readdirSync(DOMAINS_FOLDER).forEach((file, index) => fs.unlinkSync(`${DOMAINS_FOLDER}/${file}`));
 }
 
 function generateDomainFiles() {
-  const protocolText = fs.readFileSync('_data/protocol.json');
+  const protocolText = fs.readFileSync(PROTOCOL_FILE);
   const protocol = JSON.parse(protocolText);
 
   (protocol.domains).forEach((domain, idx) => {
     const name = domain.domain;
-    const fileName = '_domains/' + name + '.html';
-    const content = "---\n" +
-      "title: " + name + '\n' +
-      "idx: " + idx + '\n' +
-      "---";
+    const fileName = `${DOMAINS_FOLDER}/${name}.html`;
+    const content = `---
+title: ${name}
+idx: ${idx}
+---`;
 
     fs.writeFileSync(fileName, content);
   });

--- a/create-domain-files.js
+++ b/create-domain-files.js
@@ -4,18 +4,31 @@
  * Utility command that creates HTML file in the _domains folder for each domain found in the _data/protocol.json.
  */
 
-var fs = require('fs');
+const fs = require('fs');
 
-var protocolText = fs.readFileSync('_data/protocol.json');
-var protocol = JSON.parse(protocolText);
+clearDomainsFolder();
+generateDomainFiles();
 
-(protocol.domains).forEach(function (domain, idx) {
-  var name = domain.domain;
-  var fileName = '_domains/' + name + '.html';
-  var content = "---\n" +
-    "title: " + name + '\n' +
-    "idx: " + idx + '\n' +
-    "---";
+function clearDomainsFolder() {
+  const path = '_domains/';
+  fs.readdirSync(path).forEach((file, index) => {
+    fs.unlinkSync(path + '/' + file);
+  });
+}
 
-  fs.writeFileSync(fileName, content);
-});
+function generateDomainFiles() {
+  const protocolText = fs.readFileSync('_data/protocol.json');
+  const protocol = JSON.parse(protocolText);
+
+  (protocol.domains).forEach((domain, idx) => {
+    const name = domain.domain;
+    const fileName = '_domains/' + name + '.html';
+    const content = "---\n" +
+      "title: " + name + '\n' +
+      "idx: " + idx + '\n' +
+      "---";
+
+    fs.writeFileSync(fileName, content);
+  });
+}
+


### PR DESCRIPTION
`create-domain-files` script wasn't clearing the `_domain` folder prior to generating new files. This caused deprecated domain files never to be removed which, in turn, confused jekyll. 

Fixes #43 