### PR TITLE
Fix sidebar menu scrolling.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,9 +30,9 @@
 <body unresolved class="fullbleed layout vertical">
 
 <paper-drawer-panel id="paperDrawerPanel">
-  <div drawer>
+  <paper-header-panel drawer>
     {% include navigation.html %}
-  </div>
+  </paper-header-panel>
 
   <paper-header-panel main mode="waterfall">
     <paper-toolbar id="mainToolbar">


### PR DESCRIPTION
This is a solution from the polymer docs:

> The drawer and the main panels are not scrollable. You can set CSS overflow property on the elements to make them scrollable or use paper-header-panel.

https://elements.polymer-project.org/elements/paper-drawer-panel

You can see the result here: https://kdzwinel.github.io/debugger-protocol-viewer/

Note that it added a slight shadow under "Domains".