### PR TITLE
Docs: use `bundle` for building and running the project.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,14 +8,14 @@ More on the [Chrome DevTools Debugging Protocol](https://developer.chrome.com/de
 
 Dependencies:
 
-    gem install jekyll
+    bundle install
     npm install -g bower
 
     bower install
 
 Building:
 
-    jekyll serve # compiles site to _site/ and watches for file changes
+    bundle exec jekyll serve # compiles site to _site/ and watches for file changes
 
 Updating protocol:
 


### PR DESCRIPTION
After gemfile was added `bundle install` + `bundle exec jekyll serve` is the only setup that works for me. Using `jekyll serve` alone gives me some dependency error.  As far as I understand `bundle exec` ensures that right versions of all packages are used.