### PR TITLE
Remove unnecessary custom styles for the paper-menu

### DIFF
--- a/styles/protocol.css
+++ b/styles/protocol.css
@@ -25,13 +25,6 @@ paper-material {
   background: white;
 }
 
-paper-menu {
-  -ms-flex-grow: 1;
-  -webkit-flex-grow: 1;
-  flex-grow: 1;
-  overflow: scroll;
-}
-
 paper-menu a {
   text-decoration: none;
   display: -ms-flexbox;


### PR DESCRIPTION
This should fix the "gray bits" issue (that I can't reproduce for some reason?).

See: https://kdzwinel.github.io/debugger-protocol-viewer/v8/