### PR TITLE
make domain-dot formatting more copypaste-friendly

### DIFF
--- a/_includes/event.html
+++ b/_includes/event.html
@@ -4,8 +4,10 @@
 
 <div class="event">
   <h4 class="event-name monospace" id="event-{{event.name}}">
-    <span class="domain-dot">{{domain.domain}}.</span>
-    <span>{{event.name}}</span>
+    <span>
+      <span class="domain-dot">{{domain.domain}}.</span>
+      {{event.name}}
+    </span>
     <a href="{{permalink}}" class="permalink">#</a>
   </h4>
 

--- a/_includes/method.html
+++ b/_includes/method.html
@@ -4,8 +4,9 @@
 
 <div class="method">
   <h4 class="method-name monospace" id="method-{{method.name}}">
-    <span class="domain-dot">{{domain.domain}}.</span>
-    <span>{{method.name}}</span>
+    <span>
+      <span class="domain-dot">{{domain.domain}}.</span>{{method.name}}
+    </span>
     <a href="{{permalink}}" class="permalink">#</a>
   </h4>
 


### PR DESCRIPTION
When I copied that line it either had a space in between the two or a newline.
Small DOM change to fix that.