### PR TITLE
markdown support

### DIFF
--- a/elements/cr-domain/cr-domain-details.html
+++ b/elements/cr-domain/cr-domain-details.html
@@ -83,7 +83,7 @@
       </h4>
 
       <p class="details-description">
-        <span hidden$="[[!details.description]]" inner-h-t-m-l="[[details.description]]"></span> <cr-domain-experimental item="[[details]]"></cr-domain-experimental>
+        <cr-markdownish hidden$="[[!details.description]]" markdown="[[details.description]]"></cr-markdownish> <cr-domain-experimental item="[[details]]"></cr-domain-experimental>
       </p>
       <p hidden$="[[!details.type]]"class="type-type">Type: <strong>[[details.type]]</strong></p>
 

--- a/elements/cr-domain/cr-domain-param.html
+++ b/elements/cr-domain/cr-domain-param.html
@@ -113,8 +113,7 @@
             </span>
           </span>
           <span class="param-description">
-            <span inner-h-t-m-l="[[param.description]]" hidden$="[[!param.description]]"></span>
-
+            <cr-markdownish hidden$="[[!param.description]]" markdown=[[param.description]]></cr-markdownish>
             <span>[[_computeParamEnum(param.enum)]]</span>
             <cr-domain-experimental item="[[param]]"></cr-domain-experimental>
           </span>

--- a/elements/cr-domain/cr-domain.html
+++ b/elements/cr-domain/cr-domain.html
@@ -22,7 +22,8 @@
       <div class="paper-material" elevation="1" class="heading-domain">
         <h2 class="heading"><span>[[domain.domain]]</span> Domain</h2>
 
-        <p class="description" hidden$="[[!domain.description]]" inner-h-t-m-l="[[domain.description]]">
+        <p class="description" hidden$="[[!domain.description]]">
+            <cr-markdownish markdown="[[domain.description]]"></cr-markdownish>
         </p>
         <cr-domain-experimental item="[[domain]]"></cr-domain-experimental>
       </div>

--- a/elements/cr-markdownish/cr-markdownish.html
+++ b/elements/cr-markdownish/cr-markdownish.html
@@ -1,0 +1,136 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+
+<dom-module id="cr-markdownish">
+  <script>
+    Polymer({
+      is: 'cr-markdownish',
+      properties: {
+        /**
+         * The markdown source that should be rendered by this element.
+         */
+        markdown: {
+          type: String,
+          observer: 'render',
+        }
+      },
+      attached: function () {
+        this.render();
+      },
+      render: function () {
+        if (!this.markdown) return;
+
+        // skip the work if we don't have markdown in it.
+        const hasMarkdown = /(\n-)|`/.test(this.markdown);
+        if (!hasMarkdown) {
+          Polymer.dom(this).innerHTML = this.markdown;
+          return;
+        }
+
+        let text = this._escapeHtml(this.markdown);
+        let html = this._convertMarkdownLists(text);
+        html = this._convertMarkdownCodeBlocks(html);
+        Polymer.dom(this).innerHTML = html;
+      },
+
+      /**
+       * @param {string} text
+       * @return {!string}
+       */
+      _convertMarkdownLists(text) {
+        let inList = false;
+        let html = [];
+
+        for (const line of text.split(/\n/)) {
+          if (inList && line === '') {
+            inList = false;
+            html.push('</ul>');
+            continue;
+          }
+          if (line.startsWith('-')) {
+            if (!inList) html.push('<ul>');
+            inList = true;
+            html.push('  <li>' + line.replace(/^- /, ''));
+            continue;
+          }
+          html.push(line);
+        }
+        return html.join('\n');
+      },
+
+      /**
+       * @param {!string} text
+       * @return {!Element}
+       */
+      _convertMarkdownCodeBlocks(text) {
+        const html = [];
+        const parts = text.split(/`(.*?)`/g); // Split on markdown code slashes
+        while (parts.length) {
+          // Pop off the same number of elements as there are capture groups.
+          const [preambleText, codeText] = parts.splice(0, 2);
+          html.push(preambleText);
+          if (codeText) {
+            html.push(`<code>${codeText}</code>`);
+          }
+        }
+        return html.join('');
+      },
+
+      /**
+       * Escape special characters in the given string of html.
+       *
+       * @param  {string} string The string to escape for inserting into HTML
+       * @return {string}
+       * @see https://github.com/component/escape-html/
+       */
+      _escapeHtml(string) {
+        const matchHtmlRegExp = /["'&<>]/;
+
+        var str = '' + string;
+        var match = matchHtmlRegExp.exec(str);
+
+        if (!match) {
+          return str;
+        }
+
+        var escape;
+        var html = '';
+        var index = 0;
+        var lastIndex = 0;
+
+        for (index = match.index; index < str.length; index++) {
+          switch (str.charCodeAt(index)) {
+            case 34: // "
+              escape = '"';
+              break;
+            case 38: // &
+              escape = '&amp;';
+              break;
+            case 39: // '
+              escape = '&#39;';
+              break;
+            case 60: // <
+              escape = '&lt;';
+              break;
+            case 62: // >
+              escape = '&gt;';
+              break;
+            default:
+              continue;
+          }
+
+          if (lastIndex !== index) {
+            html += str.substring(lastIndex, index);
+          }
+
+          lastIndex = index + 1;
+          html += escape;
+        }
+
+        return lastIndex !== index ?
+          html + str.substring(lastIndex, index) :
+          html;
+      }
+    });
+
+  </script>
+</dom-module>

--- a/elements/cr-markdownish/cr-markdownish.html
+++ b/elements/cr-markdownish/cr-markdownish.html
@@ -22,14 +22,14 @@
         // skip the work if we don't have markdown in it.
         const hasMarkdown = /(\n-)|`/.test(this.markdown);
         if (!hasMarkdown) {
-          Polymer.dom(this).innerHTML = this.markdown;
+          this.innerHTML = this.markdown;
           return;
         }
 
-        let text = this._escapeHtml(this.markdown);
+        const text = this._escapeHtml(this.markdown);
         let html = this._convertMarkdownLists(text);
         html = this._convertMarkdownCodeBlocks(html);
-        Polymer.dom(this).innerHTML = html;
+        this.innerHTML = html;
       },
 
       /**
@@ -54,6 +54,8 @@
           }
           html.push(line);
         }
+        if (inList) html.push('</ul>');
+
         return html.join('\n');
       },
 

--- a/index-imports.html
+++ b/index-imports.html
@@ -18,4 +18,6 @@
 <link rel="import" href="styles/custom-paper-material-styles.html">
 
 <link rel="import" href="elements/cr-domain/cr-domain.html">
+<link rel="import" href="elements/cr-markdownish/cr-markdownish.html">
+
 <link rel="import" href="elements/cr-search-control/cr-search-control.html">


### PR DESCRIPTION
There are lots of backtick blocks these days. And there's even one list:

Before and after:

![image](https://user-images.githubusercontent.com/39191/38168931-5b3aa482-3510-11e8-9afa-152fc5bc3419.png)


Right now i'm passing the markdown in as an attribute. Is it possible to just have it as the literal innerHTML and then transform it? It didn't seem straightforward, but I'm a polymer noob. 
Given that this is fairly equivalent to what we had, I'm pretty comfortable with this anyway.

