### PR TITLE
restore some styling

### DIFF
--- a/pages/_includes/shell.hbs
+++ b/pages/_includes/shell.hbs
@@ -28,28 +28,30 @@
 </head>
 <body>
   <aside>
-    <div id="versions">
+    <div id="home" class="navs">
+      <nav>
+        <a href="{{{ url '/' }}}">Home</a>
+      </nav>
+    </div>
+    <div id="versions" class="navs">
       <header>Versions</header>
       <nav>
-        <a href="{{{ url '/1-2' }}}" name="1-2">
-          stable (1.2)
-        </a>
-        <a href="{{{ url '/1-3' }}}" name="1-3">
-          stable RC (1.3)
-        </a>
         <a href="{{{ url '/tot' }}}" name="tot">
           latest (tip-of-tree)
         </a>
         <a href="{{{ url '/v8' }}}" name="v8">
           v8-inspector (node)
         </a>
-        <a href="{{{ url '/' }}}" name="" class="homelink">
-          Home
+        <a href="{{{ url '/1-3' }}}" name="1-3">
+          stable RC (1.3)
+        </a>
+        <a href="{{{ url '/1-2' }}}" name="1-2">
+          stable (1.2)
         </a>
       </nav>
     </div>
 
-    <div id="domains" class="version-{{{version}}}">
+    <div id="domains" class="navs version-{{{version}}}">
       <header>Domains</header>
       <div class="scroller">
         <nav>

--- a/pages/domainGenerator.js
+++ b/pages/domainGenerator.js
@@ -68,7 +68,7 @@ export class DomainGenerator {
     for (const {experimental, deprecated, name, id} of items) {
       output += html`
       <div class="toc-link">
-        <a href="#${computeHash(typeName, name, id)}">${this.nameIncludingDomainTemplate(domain, name || id)}</a>
+        <a class="monospace" href="#${computeHash(typeName, name, id)}">${this.nameIncludingDomainTemplate(domain, name || id)}</a>
         ${this.statusTemplate(experimental, deprecated)}
       </div>
       `;
@@ -106,11 +106,11 @@ export class DomainGenerator {
 
   propertyTemplate(domain, items) {
     let properties = '';
-    
+
     for (const item of items) {
       const {name, description, experimental, deprecated} = item;
       properties += html`
-        <dt class="param-name">${name}</dt>
+        <dt class="param-name monospace">${name}</dt>
         <dd>
           ${this.propertiesType(domain, item)}
           ${this.descriptionTemplate(description)}
@@ -118,7 +118,7 @@ export class DomainGenerator {
         </dd>
       `;
     }
-    
+
     return properties;
   }
 
@@ -136,7 +136,7 @@ export class DomainGenerator {
     if (!name) {
       return '';
     }
-    
+
     return html`
       <h5 class="properties-name">${name}</h5>
       <dl class="properties-container">
@@ -167,22 +167,22 @@ export class DomainGenerator {
 
     return html`
       <h5 class="properties-name">Allowed Values</h5>
-      <div class="enum-container">${enumValues.join(', ')}</div>
+      <div class="enum-container monospace">${enumValues.join(', ')}</div>
     `;
   }
 
   detailsTemplate(typeName, domain, details) {
     const {name, description, id, type, experimental, deprecated} = details;
     const computedId = computeHash(typeName, name, id);
-    
+
     return html`
       <div class="details">
         <h4 class="details-name monospace" id="${computedId}">
           ${this.nameIncludingDomainTemplate(domain, name || id)}
+          ${this.statusTemplate(experimental, deprecated)}
           <a href="#${computedId}" class="permalink">#</a>
         </h4>
         ${this.descriptionTemplate(description)}
-        ${this.statusTemplate(experimental, deprecated)}
         ${type
           ? html`<p class="type-type">Type: <strong>${type}</strong></p>`
           : ''

--- a/pages/index.md
+++ b/pages/index.md
@@ -30,11 +30,11 @@ It is available in <a href="https://nodejs.org/en/blog/release/v6.3.0/">node 6.3
 <a href="https://medium.com/@paul_irish/debugging-node-js-nightlies-with-chrome-devtools-7c4a1b95ae27">debugging & profiling</a>
 of Node.js apps.
 
-<p><b><a href="1-2/">stable 1.2 protocol (1-2)</a></b> —
-The stable release of the protocol, tagged at Chrome 54. It includes a smaller subset of the complete protocol compatibilities.
-
 <p><b><a href="1-3/">stable 1.3 protocol (1-3)</a></b> —
 The stable release of the protocol, tagged at Chrome 64. It includes a smaller subset of the complete protocol compatibilities.
+
+<p><b><a href="1-2/">stable 1.2 protocol (1-2)</a></b> —
+The stable release of the protocol, tagged at Chrome 54. It includes a smaller subset of the complete protocol compatibilities.
 
 <h3>Resources</h3>
 

--- a/pages/styles/protocol.css
+++ b/pages/styles/protocol.css
@@ -212,7 +212,7 @@ span.deprecated {
 }
 
 span.domain-dot {
-  opacity: 0.6;
+  color: #555555;
 }
 
 .toc-link {
@@ -290,5 +290,5 @@ span.domain-dot {
 }
 
 h3 {
-  color: hsl(0, 0%, 62%);
+  color: hsl(0, 0%, 47%);
 }

--- a/pages/styles/protocol.css
+++ b/pages/styles/protocol.css
@@ -40,7 +40,6 @@ nav {
 }
 
 .navs header {
-  /* font-weight: bold; */
   font-size: 1.3em;
   height: 2em;
   display: flex;
@@ -285,9 +284,9 @@ span.domain-dot {
   background-image: var(--home-icon);
   background-repeat: no-repeat;
   padding-left: 26px;
-  background-size: 20px 20px;
+  background-size: 14px 14px;
   border-left: 0;
-  background-position: 3px;
+  background-position: 6px;
 }
 
 h3 {

--- a/pages/styles/protocol.css
+++ b/pages/styles/protocol.css
@@ -11,10 +11,20 @@ html, body {
   --separation-border: 1px solid rgba(0, 0, 0, 0.14);
   /* Material-like elevation shadow */
   --elevation-shadow: rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px, rgba(0, 0, 0, 0.2) 0px 3px 1px -2px;
+
+  --home-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="hsl(0, 0%, 40%)" height="36" viewBox="0 0 24 24" width="36"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>')
 }
 
 body {
   display: flex;
+}
+
+.monospace {
+  font-family: Consolas, Menlo, monospace;
+}
+
+a {
+  color: hsl(232, 50%, 45%);
 }
 
 aside {
@@ -25,14 +35,20 @@ aside {
   border-right: var(--separation-border);
 }
 
-#versions header, #domains header {
-  font-weight: bold;
+nav {
+  background-color: white;
+}
+
+.navs header {
+  /* font-weight: bold; */
   font-size: 1.3em;
   height: 2em;
   display: flex;
   justify-content: center;
   align-items: center;
   border-bottom: var(--separation-border);
+  color: #727272;
+  font-size: 16px;
 }
 
 #domains {
@@ -54,19 +70,19 @@ aside {
   overflow-y: auto;
 }
 
-#versions nav a, #domains nav a {
+.navs a {
   flex: 1;
-  display: block;
-
   font-weight: 400;
-  line-height: 18px;
-  min-height: 36px;
+  min-height: 32px;
   padding: 0 16px;
-
   border-left: 10px solid transparent;
-
   display: flex;
   align-items: center;
+  text-decoration: none;
+}
+
+.navs a:hover {
+  background-color: hsl(0,0%, 96%);
 }
 
 #domains nav a.experimental {
@@ -197,15 +213,16 @@ span.deprecated {
 }
 
 span.domain-dot {
-  color: #555555;
+  opacity: 0.6;
 }
 
 .toc-link {
-  line-height: 1.5em;
+  line-height: 1.1em;
 }
 
 .details {
   padding-bottom: 10px;
+  word-break: break-word;
 }
 
 .details:not(:last-child) {
@@ -234,18 +251,21 @@ span.domain-dot {
 
 .properties-container dt {
   flex: 1;
+  text-align: right;
 }
 
 .properties-container dd {
   flex: 2;
+  margin-left: 10px;
 }
 
-.properties-container dt {
-  text-align: right;
+.properties-container dt, .properties-container dd {
+  padding: 5px;
 }
 
 .details-description {
   display: inline;
+  font-size: 90%;
 }
 
 .details-description p {
@@ -259,4 +279,17 @@ span.domain-dot {
 .param-type {
   display: block;
   font-weight: bold;
+}
+
+#home a {
+  background-image: var(--home-icon);
+  background-repeat: no-repeat;
+  padding-left: 26px;
+  background-size: 20px 20px;
+  border-left: 0;
+  background-position: 3px;
+}
+
+h3 {
+  color: hsl(0, 0%, 62%);
 }


### PR DESCRIPTION
restoring

* apply monospace in a bunch of places where it was.
* wordbreak to avoid awkward overflow (visible at bottom of Browser domain)
* tigther lineheight on TOC (matching previous version)


and some new things

* put Home in its own nav area
* normalize the sort of versions in the nav and homepage
