### PR TITLE
Optional and enum

### DIFF
--- a/pages/domainGenerator.js
+++ b/pages/domainGenerator.js
@@ -41,13 +41,13 @@ export class DomainGenerator {
     return this.domainTemplate(data.pagination.items[0]);
   }
 
-  descriptionTemplate(description) {
-    if (!description) {
-      return '';
-    }
+  descriptionTemplate(description, item) {
+    // Some descriptions use markdown. eg. Page.printToPDF
+    // Some params have an emum: e.g. Debugger.continueToLocation
     return html`
       <div class="details-description">
-        ${marked(description)}
+        ${description ? marked(description) : ''}
+        ${item ? this.enumDetails(item) : ''}
       </div>
     `;
   }
@@ -127,7 +127,7 @@ export class DomainGenerator {
         </dt>
         <dd>
           ${this.propertiesType(domain, item)}
-          ${this.descriptionTemplate(description)}
+          ${this.descriptionTemplate(description, item)}
           ${this.statusTemplate(experimental, deprecated)}
         </dd>
       `;
@@ -179,9 +179,9 @@ export class DomainGenerator {
       return '';
     }
 
+    const enumItems = enumValues.map(e => html`<code>${e}</code>`);
     return html`
-      <h5 class="properties-name">Allowed Values</h5>
-      <div class="enum-container monospace">${enumValues.join(', ')}</div>
+      <div class="enum-container">Allowed Values: ${enumItems.join(', ')}</div>
     `;
   }
 
@@ -196,14 +196,13 @@ export class DomainGenerator {
           ${this.statusTemplate(experimental, deprecated)}
           <a href="#${computedId}" class="permalink">#</a>
         </h4>
-        ${this.descriptionTemplate(description)}
+        ${this.descriptionTemplate(description, details)}
         ${type
           ? html`<p class="type-type">Type: <strong>${type}</strong></p>`
           : ''
         }
         ${this.propertiesDetailsTemplate(domain, details)}
         ${this.returnDetailsTemplate(domain, details)}
-        ${this.enumDetails(details)}
       </div>
     `;
   }

--- a/pages/domainGenerator.js
+++ b/pages/domainGenerator.js
@@ -120,9 +120,11 @@ export class DomainGenerator {
     let properties = '';
 
     for (const item of items) {
-      const {name, description, experimental, deprecated} = item;
+      const {name, description, experimental, deprecated, optional} = item;
       properties += html`
-        <dt class="param-name monospace">${name}</dt>
+        <dt class="param-name monospace ${optional ? 'optional' : ''}">
+          ${name}
+        </dt>
         <dd>
           ${this.propertiesType(domain, item)}
           ${this.descriptionTemplate(description)}

--- a/pages/styles/protocol.css
+++ b/pages/styles/protocol.css
@@ -297,6 +297,12 @@ span.domain-dot {
   background-position: 6px;
 }
 
+h4 {
+  /* use padding rather than margin for better positioning when viewing #method-navigate, etc. */
+  margin-top: 0;
+  padding-top: 1.33em;
+}
+
 h3 {
   color: hsl(0, 0%, 47%);
 }

--- a/pages/styles/protocol.css
+++ b/pages/styles/protocol.css
@@ -275,6 +275,13 @@ span.domain-dot {
   margin-bottom: 10px;
 }
 
+.optional::after {
+  content: "optional";
+  opacity: .6;
+  font-size: 70%;
+  display: block;
+}
+
 .param-type {
   display: block;
   font-weight: bold;

--- a/pages/styles/protocol.css
+++ b/pages/styles/protocol.css
@@ -19,8 +19,14 @@ body {
   display: flex;
 }
 
-.monospace {
+.monospace, code {
   font-family: Consolas, Menlo, monospace;
+}
+
+code {
+  color: #8E24AA;
+  font-size: 15px;
+  white-space: nowrap;
 }
 
 a {


### PR DESCRIPTION
Added optional tags on optional params (thx pavel for reporting):

![image](https://user-images.githubusercontent.com/39191/80150908-0bdab200-856e-11ea-844d-31275cabea0e.png)

Print out the allowed values for an enum. We were doing this for types but not for params.
![image](https://user-images.githubusercontent.com/39191/80151017-32005200-856e-11ea-97cd-2dcf0535276d.png)

A few more style tweaks, too.