### PR TITLE
Add sliding aside for mobile

### DIFF
--- a/pages/_includes/shell.hbs
+++ b/pages/_includes/shell.hbs
@@ -31,7 +31,7 @@
     <div id="home" class="navs">
       <nav>
         <a href="{{{ url '/' }}}">Home</a>
-        <button class="aside-close-button" aria-label="Close navigation">X</button>
+        <button class="aside-close-button" aria-label="Close navigation">x</button>
       </nav>
     </div>
     <div id="versions" class="navs">

--- a/pages/_includes/shell.hbs
+++ b/pages/_includes/shell.hbs
@@ -31,6 +31,7 @@
     <div id="home" class="navs">
       <nav>
         <a href="{{{ url '/' }}}">Home</a>
+        <button class="aside-close-button" aria-label="Close navigation">X</button>
       </nav>
     </div>
     <div id="versions" class="navs">
@@ -108,7 +109,7 @@
   <main>
     <header>
       <h1>Chrome DevTools Protocol</h1>
-      <a href="{{{ url '/' }}}" class="homepage-link">Home</a>
+      <button class="menu-link">Navigation</button>
       <cr-search-control base-url="{{{ url '/' }}}" protocol-search-index="/search_index/{{{version}}}.json"></cr-search-control>
     </header>
     <section>

--- a/pages/scripts/index.js
+++ b/pages/scripts/index.js
@@ -324,7 +324,7 @@ customElements.define('cr-search-control', class extends HTMLElement {
   }
 });
 
-const menuNavigationLink = document.querySelector('.menu-link');
+const menuNavigationButton = document.querySelector('.menu-link');
 const aside = document.querySelector('aside');
 const mainSection = document.querySelector('main');
 const asideCloseButton = document.querySelector('.aside-close-button');
@@ -339,23 +339,23 @@ document.addEventListener('keydown', (event) => {
     document.querySelector('cr-search-control').inputElement.focus();
   }
   // Escape key
-  if (event.keyCode === 27 && aside.classList.contains('shown')) {
+  if (event.key === 'Escape' && aside.classList.contains('shown')) {
     aside.classList.remove('shown');
   }
 });
 
-menuNavigationLink.addEventListener('click', (event) => {
+menuNavigationButton.addEventListener('click', (event) => {
   // Don't trigger the click event on the main section
   event.stopPropagation();
   aside.addEventListener('transitionend', () => {
     // Move focus into close button of drawer
     asideCloseButton.focus();
-  });
+  }, {once: true});
   aside.classList.add('shown');
 });
 function closeAside() {
   aside.classList.remove('shown');
-  menuNavigationLink.focus();
+  menuNavigationButton.focus();
 }
 mainSection.addEventListener('click', closeAside);
 asideCloseButton.addEventListener('click', closeAside);

--- a/pages/scripts/index.js
+++ b/pages/scripts/index.js
@@ -324,6 +324,11 @@ customElements.define('cr-search-control', class extends HTMLElement {
   }
 });
 
+const menuNavigationLink = document.querySelector('.menu-link');
+const aside = document.querySelector('aside');
+const mainSection = document.querySelector('main');
+const asideCloseButton = document.querySelector('.aside-close-button');
+
 document.addEventListener('keydown', (event) => {
   // Make sure that copy-pasting works
   if (event.metaKey) {
@@ -333,4 +338,24 @@ document.addEventListener('keydown', (event) => {
   if (event.keyCode >= 65 && event.keyCode <= 90) {
     document.querySelector('cr-search-control').inputElement.focus();
   }
-})
+  // Escape key
+  if (event.keyCode === 27 && aside.classList.contains('shown')) {
+    aside.classList.remove('shown');
+  }
+});
+
+menuNavigationLink.addEventListener('click', (event) => {
+  // Don't trigger the click event on the main section
+  event.stopPropagation();
+  aside.addEventListener('transitionend', () => {
+    // Move focus into close button of drawer
+    asideCloseButton.focus();
+  });
+  aside.classList.add('shown');
+});
+function closeAside() {
+  aside.classList.remove('shown');
+  menuNavigationLink.focus();
+}
+mainSection.addEventListener('click', closeAside);
+asideCloseButton.addEventListener('click', closeAside);

--- a/pages/styles/protocol.css
+++ b/pages/styles/protocol.css
@@ -30,7 +30,7 @@ code {
   white-space: nowrap;
 }
 
-a {
+a, .aside-close-button {
   color: hsl(232, 50%, 45%);
 }
 
@@ -40,6 +40,7 @@ aside {
   min-width: 200px;
   flex-direction: column;
   border-right: var(--separation-border);
+
 }
 
 nav {
@@ -76,7 +77,7 @@ nav {
   overflow-y: auto;
 }
 
-#home a, .homepage-link {
+#home a, .menu-link {
   background-image: var(--home-icon);
   background-repeat: no-repeat;
   padding-left: 26px;
@@ -144,10 +145,14 @@ main > header h1 {
   font-weight: 400;
 }
 
-main > header .homepage-link {
+main > header .menu-link {
   background-image: var(--home-icon-for-header);
   color: var(--header-text-color);
+  background-color: inherit;
+  text-decoration: underline;
+  border: none;
   display: none;
+  font-size: 1em;
 }
 
 /* When narrow, hide page title to avoid wrapping h1 + search */
@@ -157,13 +162,38 @@ main > header .homepage-link {
   }
 }
 
+.aside-close-button {
+  display: none;
+}
+
 /* hide sidenav on mobile */
 @media only screen and (max-width:640px) {
   aside {
-    display:none;
+    transform: translate(-200px, 0);
+    position: absolute;
+    width: 200px;
+    z-index: 1;
+    background: inherit;
+    visibility: hidden;
+    transition: cubic-bezier(0,0,0.32,1);
+    transition-duration: 200ms;
   }
 
-  main > header .homepage-link {
+  aside.shown {
+    transform: none;
+    visibility: visible;
+  }
+
+  .aside-close-button {
+    display: block;
+    font-size: 1em;
+  }
+
+  #home nav {
+    display: flex;
+  }
+
+  main > header .menu-link {
     display: inline-block;
   }
 }
@@ -339,15 +369,6 @@ span.domain-dot {
 
 .param-type .param-type__array .param-type  {
   display: inline;
-}
-
-#home a {
-  background-image: var(--home-icon);
-  background-repeat: no-repeat;
-  padding-left: 26px;
-  background-size: 14px 14px;
-  border-left: 0;
-  background-position: 6px;
 }
 
 h4 {

--- a/pages/styles/protocol.css
+++ b/pages/styles/protocol.css
@@ -13,7 +13,6 @@ html, body {
   --elevation-shadow: rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px, rgba(0, 0, 0, 0.2) 0px 3px 1px -2px;
 
   --home-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="hsl(0, 0%, 40%)" height="36" viewBox="0 0 24 24" width="36"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>');
-  --home-icon-for-header: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="white" height="36" viewBox="0 0 24 24" width="36"><path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/></svg>');
 }
 
 body {
@@ -146,13 +145,18 @@ main > header h1 {
 }
 
 main > header .menu-link {
-  background-image: var(--home-icon-for-header);
   color: var(--header-text-color);
   background-color: inherit;
   text-decoration: underline;
   border: none;
   display: none;
   font-size: 1em;
+  margin-top: 20px;
+  /*
+   * Reset the background image, as we don't want it on this link,
+   * but we do want it on all others.
+   */
+  background-image: none;
 }
 
 /* When narrow, hide page title to avoid wrapping h1 + search */
@@ -187,6 +191,7 @@ main > header .menu-link {
   .aside-close-button {
     display: block;
     font-size: 1em;
+    width: 48px;
   }
 
   #home nav {


### PR DESCRIPTION
This allows us to add a navigation menu for mobile. It can slide
in when the "Navigation" button is clicked. It will slide in,
automatically focusing the close button once opened.

Clicking on the main section will also automatically hide the
menu.

<img width="700" alt="Screenshot 2020-04-27 at 17 55 14" src="https://user-images.githubusercontent.com/5948271/80399111-942fbe80-88b0-11ea-8da7-8048da0684d0.png">
<img width="700" alt="Screenshot 2020-04-27 at 17 55 22" src="https://user-images.githubusercontent.com/5948271/80399116-94c85500-88b0-11ea-9238-c366f41fa086.png">