### PR TITLE
Tweak title to include domain (but not "tot" version)

### DIFF
--- a/pages/_includes/shell.hbs
+++ b/pages/_includes/shell.hbs
@@ -9,7 +9,11 @@
     <meta name="description" content="Chrome DevTools Protocol - version {{{version}}}" />
   {{/if}}
   <link rel="icon" type="image/png" href="{{{ url '/images/logo.png'}}}" />
-  <title>{{{title}}}</title>
+  {{#if domain}}
+    <title>{{{title}}} - {{{domain.domain}}} domain</title>
+  {{else}}
+    <title>{{{title}}}</title>
+  {{/if}}
 
   <meta name="theme-color" content="#303F9F" />
   <meta name="twitter:card" content="summary" />

--- a/pages/domainGenerator.js
+++ b/pages/domainGenerator.js
@@ -22,9 +22,11 @@ export class DomainGenerator {
 
   data() {
     const version = this.version;
+    const versionPart = version === 'tot' ? '' : ` - version ${version}`;
+    const title = `Chrome DevTools Protocol${versionPart}`
     return {
       layout: 'shell.hbs',
-      title: `Chrome DevTools Protocol - ${version}`,
+      title,
       version,
       shadow: 'domain',
       pagination: {


### PR DESCRIPTION
The domainGenerator generates the title for domains in the `title`
field of the return object of `data()`. As such, we should add
the logic to remove `tot` from the title there.

`/tot/` is generated from `tot.md` per Eleventy's mapping of
Markdown files to pages. For more information, see:
https://www.11ty.dev/docs/layouts/#front-matter-data-in-layouts

All subpages with the domains are generated by the `domainGenerator`.
For example, all subpages of `/tot/` are generated by `tot.11ty.js`.

Fixes #148