### PR TITLE
Update search placeholder to indicate you can start typing immediately

### DIFF
--- a/pages/scripts/index.js
+++ b/pages/scripts/index.js
@@ -284,7 +284,7 @@ customElements.define('cr-search-control', class extends HTMLElement {
           outline: none;
         }
       </style>
-      <input placeholder="Search..." aria-label="Search" @keyup=${this.handleArrows}/>
+      <input placeholder="Start typing to search..." aria-label="Search" @keyup=${this.handleArrows}/>
     `, this.shadowRoot, {
       eventContext: this,
     });

--- a/pages/scripts/index.js
+++ b/pages/scripts/index.js
@@ -276,7 +276,7 @@ customElements.define('cr-search-control', class extends HTMLElement {
           margin-left: auto;
         }
         input::placeholder {
-          color: var(--header-text-color);
+          color: hsla(0, 0%, 100%, 0.5);
         }
         input:focus {
           transition: border-bottom-color 0.4s ease;


### PR DESCRIPTION
Not 100% yet, but I think it would be nice to teach users the fact that you can start typing without any interaction with the input box, to immediately start searching. WDYT?