### PR TITLE
Update path to browser_protocol.pdl.

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -145,7 +145,7 @@ remote connection and thus detach the extension.
 
 <h4 id="how-is-the-protocol-defined">How is the protocol defined?</h4>
 <p>The canonical protocol definitions live in the Chromium source tree:
-(<a href="https://cs.chromium.org/chromium/src/third_party/blink/renderer/core/inspector/browser_protocol.pdl">browser_protocol.pdl</a>
+(<a href="https://cs.chromium.org/chromium/src/third_party/blink/public/devtools_protocol/browser_protocol.pdl">browser_protocol.pdl</a>
 and <a href="https://cs.chromium.org/chromium/src/v8/include/js_protocol.pdl">js_protocol.pdl</a>).
 They are maintained manually by the DevTools engineering team. The declarative protocol definitions are used across tools;
 for instance, a binding layer is created within Chromium for the Chrome DevTools to interact with,


### PR DESCRIPTION
This moved in 2019 and apparently someone has noticed:

https://mango.pdf.zone/stealing-chrome-cookies-without-a-password#sidenote-the-chrome-dev-tools-are-absolutely-loose:~:text=Finally%2C%20they%20have%20a%20section%20called,to%20read%2C%20both%20of%20which%20404.