### PR TITLE
Alphabetical List of Domains Navigation

### DIFF
--- a/pages/_includes/shell.hbs
+++ b/pages/_includes/shell.hbs
@@ -60,47 +60,47 @@
       <header>Domains</header>
       <div class="scroller">
         <nav>
-          <a href="{{{ url '/' }}}{{{ version }}}/Browser" class="tot 1-3">Browser</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Debugger" class="tot 1-2 1-3 v8">Debugger</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/DOM" class="tot 1-2 1-3">DOM</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/DOMDebugger" class="tot 1-2 1-3">DOMDebugger</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Emulation" class="tot 1-2 1-3">Emulation</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Input" class="tot 1-2 1-3">Input</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/IO" class="tot 1-3">IO</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Log" class="tot 1-3">Log</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Network" class="tot 1-2 1-3">Network</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Page" class="tot 1-2 1-3">Page</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Performance" class="tot 1-3">Performance</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Profiler" class="tot 1-2 1-3 v8">Profiler</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Runtime" class="tot 1-2 1-3 v8">Runtime</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Security" class="tot 1-3">Security</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Target" class="tot 1-3">Target</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Console" class="tot deprecated v8">Console</a>
-          <a href="{{{ url '/' }}}{{{ version }}}/Schema" class="tot deprecated 1-2 v8">Schema</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Accessibility" class="tot experimental">Accessibility</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Animation" class="tot experimental">Animation</a>
           <a href="{{{ url '/' }}}{{{ version }}}/ApplicationCache" class="tot experimental">ApplicationCache</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Audits" class="tot experimental">Audits</a>
           <a href="{{{ url '/' }}}{{{ version }}}/BackgroundService" class="tot experimental">BackgroundService</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Browser" class="tot 1-3">Browser</a>
           <a href="{{{ url '/' }}}{{{ version }}}/CacheStorage" class="tot experimental">CacheStorage</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Cast" class="tot experimental">Cast</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Console" class="tot deprecated v8">Console</a>
           <a href="{{{ url '/' }}}{{{ version }}}/CSS" class="tot experimental">CSS</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Database" class="tot experimental">Database</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Debugger" class="tot 1-2 1-3 v8">Debugger</a>
           <a href="{{{ url '/' }}}{{{ version }}}/DeviceOrientation" class="tot experimental">DeviceOrientation</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/DOM" class="tot 1-2 1-3">DOM</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/DOMDebugger" class="tot 1-2 1-3">DOMDebugger</a>
           <a href="{{{ url '/' }}}{{{ version }}}/DOMSnapshot" class="tot experimental">DOMSnapshot</a>
           <a href="{{{ url '/' }}}{{{ version }}}/DOMStorage" class="tot experimental">DOMStorage</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Emulation" class="tot 1-2 1-3">Emulation</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Fetch" class="tot experimental">Fetch</a>
           <a href="{{{ url '/' }}}{{{ version }}}/HeadlessExperimental" class="tot experimental">HeadlessExperimental</a>
           <a href="{{{ url '/' }}}{{{ version }}}/HeapProfiler" class="tot experimental v8">HeapProfiler</a>
           <a href="{{{ url '/' }}}{{{ version }}}/IndexedDB" class="tot experimental">IndexedDB</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Input" class="tot 1-2 1-3">Input</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Inspector" class="tot experimental">Inspector</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/IO" class="tot 1-3">IO</a>
           <a href="{{{ url '/' }}}{{{ version }}}/LayerTree" class="tot experimental">LayerTree</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Log" class="tot 1-3">Log</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Media" class="tot experimental">Media</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Memory" class="tot experimental">Memory</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Network" class="tot 1-2 1-3">Network</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Overlay" class="tot experimental">Overlay</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Page" class="tot 1-2 1-3">Page</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Performance" class="tot 1-3">Performance</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Profiler" class="tot 1-2 1-3 v8">Profiler</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Runtime" class="tot 1-2 1-3 v8">Runtime</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Schema" class="tot deprecated 1-2 v8">Schema</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Security" class="tot 1-3">Security</a>
           <a href="{{{ url '/' }}}{{{ version }}}/ServiceWorker" class="tot experimental">ServiceWorker</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Storage" class="tot experimental">Storage</a>
           <a href="{{{ url '/' }}}{{{ version }}}/SystemInfo" class="tot experimental">SystemInfo</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Target" class="tot 1-3">Target</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Tethering" class="tot experimental">Tethering</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Tracing" class="tot experimental">Tracing</a>
           <a href="{{{ url '/' }}}{{{ version }}}/WebAudio" class="tot experimental">WebAudio</a>


### PR DESCRIPTION
I'm dyslexic and struggled with reading and finding items in the left-hand nav bar.  Currently, Domains are grouped by "experimental", "deprecated", and "production", and ordered alphabetically within those groups.  I feel reading accessibility could be improved if we saw items ordered by name.  The lack of group subheaders does not make this list intuitive for me to understand, and I didn't immediately notice the group colors on the left, nor identify their significance (some users are colorblind)

### Before
<img width="479" alt="1-domains-plist-before" src="https://user-images.githubusercontent.com/10064176/145690647-89ee9653-86a3-4e98-9dad-d81c4d6a1e55.png">

### After
<img width="479" alt="2-domains-list-after" src="https://user-images.githubusercontent.com/10064176/145690652-933466ea-9a21-4a3e-8555-1c40976521e7.png">

