### PR TITLE
Remove `npm run deploy` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@11ty/eleventy": "0.10.0",
     "@rollup/plugin-node-resolve": "7.1.1",
     "esm": "3.2.25",
-    "gh-pages": "^2.0.1",
     "lit-html": "1.2.1",
     "marked": "0.8.2",
     "rimraf": "^3.0.2",
@@ -21,7 +20,6 @@
   "scripts": {
     "build": "rimraf devtools-protocol/ && node -r esm node_modules/.bin/eleventy && rollup -c rollup.config.js",
     "prep": "bash prep-tot-protocol-files.sh",
-    "serve": "echo 'Open http://localhost:8696/devtools-protocol/ for built site'; statikk --port 8696 .",
-    "deploy": "gh-pages --dist devtools-protocol --repo git@github.com:ChromeDevTools/devtools-protocol.git --dotfiles  --user \"devtools-bot <24444246+devtools-bot@users.noreply.github.com>\""
+    "serve": "echo 'Open http://localhost:8696/devtools-protocol/ for built site'; statikk --port 8696 ."
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -25,11 +25,7 @@ Deploying:
 
 We deploy to https://chromedevtools.github.io/devtools-protocol/ despite the source living here.
 The [repo/branch layout is described here](https://github.com/ChromeDevTools/debugger-protocol-viewer/issues/78).
-Master branch of this repo is deployed every hour (on the 15 minute mark) via the [devtools-protocol/scripts/update-n-publish-docs.sh](https://github.com/ChromeDevTools/devtools-protocol/blob/master/scripts/update-n-publish-docs.sh) script.
-
-```sh
-npm run deploy
-```
+There is no need to manually trigger deployments. It’s done [automatically](https://github.com/ChromeDevTools/devtools-protocol/commit/c9c207e583264058326792210d1b29a95109beac) as part of the devtools-protocol GitHub Actions workflow.
 
 ## Adding new version
 


### PR DESCRIPTION
The GitHub Actions workflow now takes care of automatic deployment.

Issue: https://github.com/ChromeDevTools/devtools-protocol/issues/278