### PR TITLE
Add Extensions domain to sidebar

### DIFF
--- a/pages/_includes/shell.hbs
+++ b/pages/_includes/shell.hbs
@@ -80,6 +80,7 @@
           <a href="{{{ url '/' }}}{{{ version }}}/DOMStorage" class="tot experimental">DOMStorage</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Emulation" class="tot 1-2 1-3">Emulation</a>
           <a href="{{{ url '/' }}}{{{ version }}}/EventBreakpoints" class="tot experimental">EventBreakpoints</a>
+          <a href="{{{ url '/' }}}{{{ version }}}/Extensions" class="tot experimental">Extensions</a>
           <a href="{{{ url '/' }}}{{{ version }}}/FedCm" class="tot experimental">FedCm</a>
           <a href="{{{ url '/' }}}{{{ version }}}/Fetch" class="tot 1-3">Fetch</a>
           <a href="{{{ url '/' }}}{{{ version }}}/HeadlessExperimental" class="tot experimental">HeadlessExperimental</a>


### PR DESCRIPTION
Adds the new Extensions domain to the sidebar. This currently contains a method used for loading unpacked extensions and there are plans to expand it over time.